### PR TITLE
NewMediaHandler honours MaxMediaSize, add WithMaxMemory

### DIFF
--- a/codecov.yaml
+++ b/codecov.yaml
@@ -3,3 +3,13 @@ comment:
 
 ignore:
 - 'examples/'
+
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 80%
+    patch:
+      default:
+        enabled: no # disable patch since it is noisy and not correct

--- a/micropub/media_handler.go
+++ b/micropub/media_handler.go
@@ -55,9 +55,13 @@ func NewMediaHandler(mediaUploader MediaUploader, scopeChecker ScopeChecker, opt
 			return
 		}
 
+		if conf.MaxMediaSize != 0 {
+			r.Body = http.MaxBytesReader(w, r.Body, conf.MaxMediaSize)
+		}
+
 		err := r.ParseMultipartForm(conf.MaxMediaSize)
 		if err != nil {
-			serveError(w, fmt.Errorf("%w: file is too large", ErrBadRequest))
+			serveError(w, fmt.Errorf("%w: %w", ErrBadRequest, err))
 			return
 		}
 

--- a/micropub/media_handler.go
+++ b/micropub/media_handler.go
@@ -59,7 +59,7 @@ func NewMediaHandler(mediaUploader MediaUploader, scopeChecker ScopeChecker, opt
 			r.Body = http.MaxBytesReader(w, r.Body, conf.MaxMediaSize)
 		}
 
-		err := r.ParseMultipartForm(conf.MaxMediaSize)
+		err := r.ParseMultipartForm(0)
 		if err != nil {
 			serveError(w, fmt.Errorf("%w: %w", ErrBadRequest, err))
 			return

--- a/micropub/media_handler.go
+++ b/micropub/media_handler.go
@@ -23,6 +23,7 @@ type ScopeChecker func(r *http.Request, scope string) bool
 // MediaConfiguration is the configuration for a media handler.
 type MediaConfiguration struct {
 	MaxMediaSize int64
+	MaxMemory    int64
 }
 
 // MediaOption is an option that configures [MediaConfiguration].
@@ -31,6 +32,15 @@ type MediaOption func(*MediaConfiguration)
 // WithMaxMediaSize configures the maximum size of media uploads, in bytes. By
 // default it is 20 MiB.
 func WithMaxMediaSize(size int64) MediaOption {
+	return func(conf *MediaConfiguration) {
+		conf.MaxMediaSize = size
+	}
+}
+
+// WithMaxMemory configures how much of the uploads are kept in memory. See
+// [http.Request.ParseMultipartForm] for more details. By default it is 0, meaning
+// that the upload is kept in temporary files.
+func WithMaxMemory(size int64) MediaOption {
 	return func(conf *MediaConfiguration) {
 		conf.MaxMediaSize = size
 	}
@@ -59,7 +69,7 @@ func NewMediaHandler(mediaUploader MediaUploader, scopeChecker ScopeChecker, opt
 			r.Body = http.MaxBytesReader(w, r.Body, conf.MaxMediaSize)
 		}
 
-		err := r.ParseMultipartForm(0)
+		err := r.ParseMultipartForm(conf.MaxMemory)
 		if err != nil {
 			serveError(w, fmt.Errorf("%w: %w", ErrBadRequest, err))
 			return

--- a/micropub/media_handler_test.go
+++ b/micropub/media_handler_test.go
@@ -1,0 +1,87 @@
+package micropub
+
+import (
+	"bytes"
+	"crypto/rand"
+	"io"
+	"mime/multipart"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func makeRandomBytes(t *testing.T, n int64) []byte {
+	data := make([]byte, n)
+	_, err := rand.Read(data)
+	require.NoError(t, err)
+	return data
+}
+
+func TestMediaHandler(t *testing.T) {
+	makeFormFile := func(t *testing.T, data []byte) (io.Reader, *multipart.Writer) {
+		bodyBuf := &bytes.Buffer{}
+		bodyWriter := multipart.NewWriter(bodyBuf)
+
+		part, err := bodyWriter.CreateFormFile("file", "text.dat")
+		require.NoError(t, err)
+
+		_, err = part.Write(data)
+		require.NoError(t, err)
+
+		err = bodyWriter.Close()
+		require.NoError(t, err)
+
+		return bodyBuf, bodyWriter
+	}
+
+	scopeChecker := func(r *http.Request, scope string) bool {
+		return scope == "media"
+	}
+
+	t.Run("OK Request", func(t *testing.T) {
+		data := makeRandomBytes(t, 1024)
+
+		uploader := func(file multipart.File, header *multipart.FileHeader) (string, error) {
+			received := make([]byte, 1024)
+			_, err := file.Read(received)
+			require.NoError(t, err)
+			require.True(t, bytes.Equal(data, received))
+			return "https://example.com/text.dat", nil
+		}
+
+		body, mp := makeFormFile(t, data)
+
+		w := httptest.NewRecorder()
+		r := httptest.NewRequest(http.MethodPost, "/", body)
+		r.Header.Set("Content-Type", mp.FormDataContentType())
+
+		handler := NewMediaHandler(uploader, scopeChecker)
+		handler.ServeHTTP(w, r)
+		assert.Equal(t, http.StatusCreated, w.Result().StatusCode)
+		assert.Equal(t, "https://example.com/text.dat", w.Result().Header.Get("Location"))
+	})
+
+	t.Run("Max Size", func(t *testing.T) {
+		data := makeRandomBytes(t, 1024)
+
+		uploader := func(file multipart.File, header *multipart.FileHeader) (string, error) {
+			return "", ErrNotImplemented
+		}
+
+		body, mp := makeFormFile(t, data)
+		w := httptest.NewRecorder()
+		r := httptest.NewRequest(http.MethodPost, "/", body)
+		r.Header.Set("Content-Type", mp.FormDataContentType())
+
+		handler := NewMediaHandler(uploader, scopeChecker, WithMaxMediaSize(512))
+		handler.ServeHTTP(w, r)
+		assert.Equal(t, http.StatusBadRequest, w.Result().StatusCode)
+
+		requestBody, err := io.ReadAll(w.Result().Body)
+		assert.NoError(t, err)
+		assert.EqualValues(t, `{"error":"invalid_request","error_description":"invalid request: http: request body too large"}`+"\n", string(requestBody))
+	})
+}


### PR DESCRIPTION
As pointed out by @jlelse, the argument taken by `r.ParseMultipartForm` only limits the amount of the request that is kept in memory, the rest is in disk. Therefore, the option was not really doing what it was meant to: prevent too large uploads. 