### PR TITLE
Set text/plain content-type on Micropub create response

### DIFF
--- a/micropub/handler.go
+++ b/micropub/handler.go
@@ -304,6 +304,7 @@ func (h *handler) micropubPost(w http.ResponseWriter, r *http.Request) {
 			serveError(w, err)
 			return
 		}
+		w.Header().Set("Content-Type", "text/plain")
 		http.Redirect(w, r, location, http.StatusAccepted)
 	case ActionUpdate:
 		if !h.checkScope(w, r, "update") {

--- a/micropub/handler_test.go
+++ b/micropub/handler_test.go
@@ -226,13 +226,17 @@ func TestRouterPost(t *testing.T) {
 			case ActionCreate:
 				assert.Equal(t, "https://example.org/1", w.Result().Header.Get("Location"))
 				assert.Equal(t, http.StatusAccepted, w.Result().StatusCode)
+				assert.Equal(t, "text/plain", w.Result().Header.Get("Content-Type"))
 			case ActionUpdate:
 				assert.Equal(t, request.response.URL, w.Result().Header.Get("Location"))
 				assert.Equal(t, http.StatusOK, w.Result().StatusCode)
+				assert.Equal(t, "", w.Result().Header.Get("Content-Type"))
 			case ActionDelete:
 				assert.Equal(t, http.StatusOK, w.Result().StatusCode)
+				assert.Equal(t, "", w.Result().Header.Get("Content-Type"))
 			case ActionUndelete:
 				assert.Equal(t, http.StatusOK, w.Result().StatusCode)
+				assert.Equal(t, "", w.Result().Header.Get("Content-Type"))
 			}
 		}
 	})


### PR DESCRIPTION
This fixes compatibility with the Sparkles micropub client (https://sparkles.sploot.com/)