### PR TITLE
add ability to configure post statuses

### DIFF
--- a/micropub/handler.go
+++ b/micropub/handler.go
@@ -17,12 +17,13 @@ var (
 // Configuration is the configuration of a [Router]. Use the different [Option]
 // to customize your endpoint.
 type Configuration struct {
-	MediaEndpoint  string
-	GetSyndicateTo func() []Syndication
-	GetChannels    func() []Channel
-	GetCategories  func() []string
-	GetPostTypes   func() []PostType
-	GetVisibility  func() []string
+	MediaEndpoint   string
+	GetSyndicateTo  func() []Syndication
+	GetChannels     func() []Channel
+	GetCategories   func() []string
+	GetPostStatuses func() []string
+	GetPostTypes    func() []PostType
+	GetVisibility   func() []string
 }
 
 // PostType is used to provide information regarding the server's [supported vocabulary].
@@ -99,6 +100,16 @@ func WithGetPostTypes(getPostTypes func() []PostType) Option {
 func WithGetVisibility(getVisibility func() []string) Option {
 	return func(conf *Configuration) {
 		conf.GetVisibility = getVisibility
+	}
+}
+
+// WithGetPostStatuses configures the getter for supported [post-status]. Return an
+// empty slice if only published post statuses are supported.
+//
+// [post-status]: https://indieweb.org/Micropub-extensions#Post_Status
+func WithGetPostStatuses(getPostStatuses func() []string) Option {
+	return func(conf *Configuration) {
+		conf.GetPostStatuses = getPostStatuses
 	}
 }
 
@@ -207,6 +218,9 @@ func (h *handler) micropubGet(w http.ResponseWriter, r *http.Request) {
 		}
 		if categories := h.conf.GetCategories(); len(categories) != 0 {
 			config["categories"] = categories
+		}
+		if postStatuses := h.conf.GetPostStatuses(); len(postStatuses) != 0 {
+			config["post-status"] = postStatuses
 		}
 		if postTypes := h.conf.GetPostTypes(); len(postTypes) != 0 {
 			config["post-types"] = postTypes

--- a/micropub/handler_test.go
+++ b/micropub/handler_test.go
@@ -136,6 +136,9 @@ func TestRouterGet(t *testing.T) {
 			WithGetVisibility(func() []string {
 				return []string{"public"}
 			}),
+			WithGetPostStatuses(func() []string {
+				return []string{"published", "draft"}
+			}),
 		}
 
 		w := httptest.NewRecorder()
@@ -146,7 +149,7 @@ func TestRouterGet(t *testing.T) {
 		assert.Equal(t, http.StatusOK, w.Result().StatusCode)
 		body, err := io.ReadAll(w.Result().Body)
 		assert.NoError(t, err)
-		assert.EqualValues(t, `{"categories":["a","b"],"media-endpoint":"https://example.com/media","visibility":["public"]}`+"\n", string(body))
+		assert.EqualValues(t, `{"categories":["a","b"],"media-endpoint":"https://example.com/media","post-status":["published","draft"],"visibility":["public"]}`+"\n", string(body))
 	})
 
 	t.Run("?q=category, syndicate-to, channel", func(t *testing.T) {


### PR DESCRIPTION
fixes #54

The configured post statuses will be returned in `?q=config` and then allows micropub clients to configure their behaviour.

---

for example, configuring the server with:
```go
micropub.NewHandler(
    &micropubImplementation{s},
    micropub.WithGetPostStatuses(func() []string {
        return []string{"published", "draft"}
    }),
)
```

and when fetching the config it returns:
```
$ curl -H "Authorization: Bearer ${TOKEN}" "http://localhost:5050/micropub?q=config"
{"post-status":["published","draft"]}
```